### PR TITLE
调用工具参数兼容json格式

### DIFF
--- a/src/python/src/nacos_mcp_router/router.py
+++ b/src/python/src/nacos_mcp_router/router.py
@@ -452,7 +452,10 @@ def create_mcp_app() -> Server:
                     content = await add_mcp_server(arguments["mcp_server_name"])
                     return [types.TextContent(type="text", text=content)]
                 case "use_tool":
-                    params = json.loads(arguments["params"])
+                    if isinstance(arguments["params"], str):
+                        params = json.loads(arguments["params"])
+                    else:
+                        params = arguments["params"]
                     content = await use_tool(arguments["mcp_server_name"], arguments["mcp_tool_name"], params)
                     return [types.TextContent(type="text", text=content)]
                 case _:


### PR DESCRIPTION
当我在cline中使用nacos-mcp-router时，在使用工具阶段，大模型经常会生成以下格式的调用参数（即使使用deepseek-R1等比较优秀的模型）：
```
{
  "mcp_server_name": "weather",
  "mcp_tool_name": "get_weather",
  "params": {
     "city_name": "Beijing"
  }
}
```
此时params参数是一个json结构，而不是字符串格式。当代码中使用 `json.loads(arguments["params"])` 进行解析时就会出错。

希望可以考虑在nacos-mpc-router处理的地方进行一个兼容，减少不必要的重试和token消耗