### PR TITLE
fix: forward registered headers to downstream MCP servers

### DIFF
--- a/src/python/src/nacos_mcp_router/mcp_transport.py
+++ b/src/python/src/nacos_mcp_router/mcp_transport.py
@@ -20,3 +20,20 @@ class McpTransport:
 
     def clean_headers(self, client_headers: dict[str, str]) -> dict[str, str]:
         return {k: v for k, v in client_headers.items() if k != 'Content-Length' and k != 'content-length' and k != 'host' and k != 'Host'}
+
+    def merged_headers(self, client_headers: dict[str, str]) -> dict[str, str]:
+        """Merge registered headers (self.headers) with client request headers.
+
+        - Registered headers (e.g. auth headers from the Nacos registration config)
+          take precedence so downstream servers always receive them.
+        - Other headers from the client are passed through.
+        - Deduplication is case-insensitive: client header names may be lowercase,
+          and keeping both would send two same-named headers that confuse downstream
+          parsers."""
+        merged = self.clean_headers(client_headers)
+        for k, v in self.headers.items():
+            lk = k.lower()
+            for mk in [mk for mk in merged if mk.lower() == lk]:
+                del merged[mk]
+            merged[k] = v
+        return merged

--- a/src/python/src/nacos_mcp_router/sse_transport.py
+++ b/src/python/src/nacos_mcp_router/sse_transport.py
@@ -20,7 +20,7 @@ class McpSseTransport(McpTransport):
         # 使用特定headers连接目标服务器
         async with sse_client(
             url=self.url,
-            headers=self.clean_headers(client_headers)
+            headers=self.merged_headers(client_headers)
         ) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -30,7 +30,7 @@ class McpSseTransport(McpTransport):
 
         async with sse_client(
             url=self.url,
-            headers=self.clean_headers(client_headers)
+            headers=self.merged_headers(client_headers)
         ) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -38,7 +38,7 @@ class McpSseTransport(McpTransport):
     async def handle_initialize(self, client_headers: dict[str, str]) -> InitializeResult:
         async with sse_client(
             url=self.url,
-            headers=self.clean_headers(client_headers)
+            headers=self.merged_headers(client_headers)
         ) as (read, write):
             async with ClientSession(read, write) as session:
                 return await session.initialize()

--- a/src/python/src/nacos_mcp_router/streamable_http_transport.py
+++ b/src/python/src/nacos_mcp_router/streamable_http_transport.py
@@ -21,7 +21,7 @@ class McpStreamableHttpTransport(McpTransport):
         
         async with streamablehttp_client(
             url=self.url,
-            headers=self.clean_headers(client_headers)
+            headers=self.merged_headers(client_headers)
         ) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -29,7 +29,7 @@ class McpStreamableHttpTransport(McpTransport):
     async def handle_list_tools(self, client_headers: dict[str, str]) -> ListToolsResult:
         async with streamablehttp_client(
             url=self.url,
-            headers=self.clean_headers(client_headers)
+            headers=self.merged_headers(client_headers)
         ) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -38,7 +38,7 @@ class McpStreamableHttpTransport(McpTransport):
     async def handle_initialize(self, client_headers: dict[str, str]) -> InitializeResult:
         async with streamablehttp_client(
             url=self.url,
-            headers=self.clean_headers(client_headers)
+            headers=self.merged_headers(client_headers)
         ) as (read, write, _):
             async with ClientSession(read, write) as session:
                 return await session.initialize()


### PR DESCRIPTION
## Problem

`McpSseTransport` and `McpStreamableHttpTransport` accept a `headers` dict in their constructor (e.g. auth headers from the Nacos registration config, passed via `CustomServer`), but every `handle_*` method only used the client request headers (`self.clean_headers(client_headers)`). The registered headers were silently dropped and **never sent to the downstream MCP server**.

Impact: any header configured in the Nacos MCP server registration (e.g. `Authorization` for secured downstream servers) has no effect.

## Fix

Add `McpTransport.merged_headers()` that merges both sources:

- **Registered headers (`self.headers`) take precedence**, so downstream always receives them
- Client request headers are passed through as before
- Deduplication is **case-insensitive** — client header names may arrive lowercase (e.g. via starlette), and keeping both would send two same-named headers that confuse downstream parsers (some servers only read the first)

Updated both `McpSseTransport` and `McpStreamableHttpTransport` to use it in `handle_initialize`, `handle_list_tools` and `handle_tool_call`.

## Files

- `src/python/src/nacos_mcp_router/mcp_transport.py` — add `merged_headers()`
- `src/python/src/nacos_mcp_router/sse_transport.py` — use merged headers
- `src/python/src/nacos_mcp_router/streamable_http_transport.py` — use merged headers