### PR TITLE
fix: stop logging full client headers in handle_list_tools

### DIFF
--- a/src/python/src/nacos_mcp_router/sse_transport.py
+++ b/src/python/src/nacos_mcp_router/sse_transport.py
@@ -26,7 +26,7 @@ class McpSseTransport(McpTransport):
                 await session.initialize()
                 return await session.call_tool(name=name, arguments=args)
     async def handle_list_tools(self, client_headers: dict[str, str]) -> ListToolsResult:
-        NacosMcpRouteLogger.get_logger().info(f"handle_list_tools, url: {self.url}, headers: {client_headers}")
+        NacosMcpRouteLogger.get_logger().info(f"handle_list_tools, url: {self.url}")
 
         async with sse_client(
             url=self.url,


### PR DESCRIPTION
## Problem

`McpSseTransport.handle_list_tools` logs the **entire client request headers dict**:

```python
NacosMcpRouteLogger.get_logger().info(f"handle_list_tools, url: {self.url}, headers: {client_headers}")
```

Client request headers may contain sensitive values (`Authorization`, bearer tokens, cookies, internal auth headers). When the router is used to proxy secured downstream MCP servers, these values are written to the log file in plaintext.

## Fix

Log only the URL, drop the headers from the log line.

## Files

- `src/python/src/nacos_mcp_router/sse_transport.py` — remove headers from log message